### PR TITLE
Add null check

### DIFF
--- a/Mvc.CascadeDropDown/DropDownListExtensions.cs
+++ b/Mvc.CascadeDropDown/DropDownListExtensions.cs
@@ -302,6 +302,36 @@ namespace Mvc.CascadeDropDown
                 options);
         }
 
+        public static MvcHtmlString CascadingDropDownList(
+            this HtmlHelper htmlHelper,
+            string inputName,
+            string inputId,
+            string triggeredByProperty,
+            string url,
+            string ajaxActionParamName,
+            string selectedValue,
+            string optionLabel = null,
+            bool disabledWhenParentNotSelected = false,
+            object htmlAttributes = null,
+            CascadeDropDownOptions options = null)
+        {
+
+            return CascadingDropDownList(
+                htmlHelper,
+                inputName,
+                inputId,
+                triggeredByProperty,
+                url,
+                ajaxActionParamName,
+                selectedValue,
+                optionLabel,
+                disabledWhenParentNotSelected,
+                htmlAttributes != null
+                ? HtmlHelper.AnonymousObjectToHtmlAttributes(htmlAttributes)
+                : new RouteValueDictionary(),
+                options);
+        }        
+        
         public static MvcHtmlString CascadingDropDownListFor<TModel, TProperty, TProperty2>(
             this HtmlHelper<TModel> htmlHelper,
             Expression<Func<TModel, TProperty>> expression,

--- a/Mvc.CascadeDropDown/DropDownListExtensions.cs
+++ b/Mvc.CascadeDropDown/DropDownListExtensions.cs
@@ -530,8 +530,12 @@ namespace Mvc.CascadeDropDown
             string stringVal = null;
             if (src != null)
             {
-                var propVal = src.GetType().GetProperty(propName).GetValue(src, null);
-                stringVal = propVal != null ? propVal.ToString() : null;
+                var prop = src.GetType().GetProperty(propName);
+                if(prop != null)
+                {
+                    var propVal = prop.GetValue(src, null);
+                    stringVal = propVal != null ? propVal.ToString() : null;
+                }
             }
             return stringVal;
         }


### PR DESCRIPTION
When directly using Html.CascadingDropDownList() and the Model is null, then will result in a System.NullReferenceException (Detail s: https://github.com/alexanderar/Mvc.CascadeDropDown/issues/22)